### PR TITLE
Allow optional configuration of float type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wabt"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -32,7 +32,7 @@
 //! )
 //! "#;
 //! 
-//! let mut parser = ScriptParser::from_str(wast)?;
+//! let mut parser = ScriptParser::<f32, f64>::from_str(wast)?;
 //! while let Some(Command { kind, .. }) = parser.next()? { 
 //!     match kind {
 //!         CommandKind::Module { module, name } => {


### PR DESCRIPTION
This is useful for parsing NaNs on 32-bit platforms, since even returning a float from a function (and maybe passing one in too, although that is unclear) can quieten a NaN. To preserve the bits precisely, we allow the consumer of the library to treat these as integers.