### PR TITLE
Update wabt-sys bindings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 keywords = ["tools", "webassembly", "wasm"]
 
 [dependencies]
-wabt-sys = { path = "wabt-sys", version = "0.2.0" }
+wabt-sys = { path = "wabt-sys", version = "0.3.0" }
 serde_json = "1.0"
 serde_derive = "1.0"
 serde = "1.0"

--- a/wabt-sys/Cargo.toml
+++ b/wabt-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wabt-sys"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/pepyakin/wabt-rs"


### PR DESCRIPTION
The currently published version of wabt-sys links to a version of wabt that can not handle mutable global import/exports yet, which breaks the wast script parser if used with recent versions of the official testsuite.

According to https://github.com/WebAssembly/spec/issues/864, this is functionality that is intended to be supported by the MVP.

I've locally confirmed that the new version can handle the current version the testsuite.