### PR TITLE
wabt-sys: Require cmake 0.1.32 or later.

### DIFF
--- a/wabt-sys/Cargo.toml
+++ b/wabt-sys/Cargo.toml
@@ -10,5 +10,5 @@ categories = ["external-ffi-bindings"]
 keywords = ["tools", "webassembly", "wasm"]
 
 [build-dependencies]
-cmake = "0.1.25"
+cmake = "0.1.32"
 cc = "1.0.4"


### PR DESCRIPTION
The usage of `no_build_target` that was added recently requires
version 0.1.32 of the cmake crate or later.