### PR TITLE
clippy: Return expression directly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,7 @@ impl Script {
     fn write_binaries(&self, source: &str) -> Result<WabtWriteScriptResult, Error> {
         let source_cstr = CString::new(source)?;
 
-        let result = unsafe {
+        unsafe {
             let raw_script_result = ffi::wabt_write_binary_spec_script(
                 self.raw_script,
                 source_cstr.as_ptr(),
@@ -447,8 +447,7 @@ impl Script {
                 0,
                 0);
             Ok(WabtWriteScriptResult { raw_script_result })
-        };
-        result
+        }
     }
 }
 

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -258,8 +258,7 @@ fn parse_value_list<F32: FromBits<u32>, F64: FromBits<u64>>(
 // This conversion is incorrect in general case (casting char to u8)!!!
 fn jstring_to_rstring(jstring: &str) -> String {
     let jstring_chars: Vec<u8> = jstring.chars().map(|c| c as u8).collect();
-    let rstring = String::from_utf8(jstring_chars).unwrap();
-    rstring
+    String::from_utf8(jstring_chars).unwrap()
 }
 
 fn parse_action<F32: FromBits<u32>, F64: FromBits<u64>>(test_action: &json::Action) -> Result<Action<F32, F64>, Error> {


### PR DESCRIPTION
We don't need to introduce an extra temporary here just to then
return that value.