### PR TITLE
make ErrorKind public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,15 +47,25 @@ impl error::Error for Error {
     }
 }
 
+/// ErrorKind describes an error condition from a wasm module operation, as well as the
+/// corresponding error message from `wabt`, if any.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ErrorKind {
+    /// Result contained an unexpected null byte.
     Nul,
+    /// Error deserializing binary wasm.
     Deserialize(String),
+    /// Error parsing textual wasm.
     Parse(String),
+    /// Error serializing a wasm module to text.
     WriteText,
+    /// Translating a wasm binary module to text yielded non-utf8 characters.
     NonUtf8Result,
+    /// Error serializing a wasm module to binary.
     WriteBinary,
+    /// Error resolving names in the wasm module.
     ResolveNames(String),
+    /// Error validating the wasm module.
     Validate(String),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,6 @@ use wabt_sys as ffi;
 pub mod script;
 
 /// A structure to represent errors coming out from wabt.
-///
-/// Actual errors are not yet published.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Error(ErrorKind);
 
@@ -50,7 +48,7 @@ impl error::Error for Error {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-enum ErrorKind {
+pub enum ErrorKind {
     Nul,
     Deserialize(String),
     Parse(String),


### PR DESCRIPTION
Is there anything prohibiting `ErrorKind` from being `pub`? I'd like to access the message from wabt for parse errors and this seems like it'd enable nicer output for other error cases as well.

If this is not pub to avoid end users matching on `Error` or `ErrorKind`, would you be open to a helper on `Error` similar to `description` that returns an Option of the underlying `wabt` error string?