### PR TITLE
Add accessor to Error to retrieve ErrorKind

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,13 @@ pub mod script;
 #[derive(Debug, PartialEq, Eq)]
 pub struct Error(ErrorKind);
 
+impl Error {
+    /// Returns the `ErrorKind` for this Error.
+    pub fn kind(&self) -> &ErrorKind {
+        &self.0
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // TODO: A better formatting


### PR DESCRIPTION
Embarrassingly, in #37 I made `ErrorKind` public but not a way to _get_ the `ErrorKind` I'd wanted. This time I've actually built the change I want downstream on a local branch, and am sure this is all I was missing. Sorry about that 😅