### PR TITLE
Update wabt dependency to latest HEAD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wabt"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "Apache-2.0"
 readme = "README.md"
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 keywords = ["tools", "webassembly", "wasm"]
 
 [dependencies]
-wabt-sys = { path = "wabt-sys", version = "0.6.1" }
+wabt-sys = { path = "wabt-sys", version = "0.6.2" }
 serde_json = "1.0"
 serde_derive = "1.0"
 serde = "1.0"

--- a/wabt-sys/Cargo.toml
+++ b/wabt-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wabt-sys"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/pepyakin/wabt-rs"


### PR DESCRIPTION
I am attempting to run WASM SIMD spec tests with constants and wabt previously had a bug parsing these; this bug is fixed in https://github.com/WebAssembly/wabt/commit/51c05065c9cd2a09f7a9e82ead17263b6d097395. @pepyakin, not sure if this PR follows your flow for bumping and releasing this project so please excuse any oversights. To update wabt I simply did the equivalent of `cd wabt-sys/wabt; git pull`.